### PR TITLE
Changing 'this' context to the appearing node so it's passed to the call...

### DIFF
--- a/jquery.domnodeappear.js
+++ b/jquery.domnodeappear.js
@@ -18,9 +18,10 @@
 
     // on animation start, execute the callback
     $(document).on('animationstart webkitAnimationStart oanimationstart MSAnimationStart', function(e){
+      var self = $(e.target);
       if (e.originalEvent.animationName == 'nodeInserted') {
         if (typeof callback == 'function') {
-          callback.call(this);
+          callback.call(self);
         }
       }
     });


### PR DESCRIPTION
I've wanted to reference only the node appearing in a couple instances so thought this would be a useful change. Currently "this" just refers to the document.
